### PR TITLE
Publish pyopf 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Added
+### Changed
+### Fixed
+### Removed
+
+## 1.4.0
+
+### Added
+
+- Added the functionality for `opf2nerf` to output the `avg_pos` and `scale` when using with `--nerfstudio`.
+- Added the original resources to the metadata of resolved project items.
+
+### Fixed
+
+- Version check for compatibility.
+
 ## 1.3.1
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pyopf"
-version = "1.3.1"
+version = "1.4.0"
 description = "Python library for I/O and manipulation of projects under the Open Photogrammetry Format (OPF)"
 authors = [
     "Pix4D",

--- a/src/pyopf/VersionInfo.py
+++ b/src/pyopf/VersionInfo.py
@@ -82,10 +82,14 @@ class VersionInfo:
         return cls(major, minor, prerelease)
 
     def compatible_with(self, other):
-        if self.major != other.major or self.prerelease != other.prerelease:
+        # self is the version of the file we read
+        # other is the version of the reader code
+        if self.major != other.major:
             return False
         if self.major > 0:
-            if self.prerelease is not None and self.minor != other.minor:
+            if other.prerelease is not None and (
+                self.minor != other.minor or self.prerelease != other.prerelease
+            ):
                 return False
         elif self.major == 0 and self.minor != other.minor:
             return False

--- a/src/pyopf/project/metadata.py
+++ b/src/pyopf/project/metadata.py
@@ -4,7 +4,13 @@ from uuid import UUID, uuid4
 
 from ..VersionInfo import VersionInfo
 from ..versions import FormatVersion
-from .project import Generator, ProjectItem, ProjectItemType, ProjectSource
+from .project import (
+    Generator,
+    ProjectItem,
+    ProjectItemType,
+    ProjectResource,
+    ProjectSource,
+)
 
 
 class Sources:
@@ -20,6 +26,7 @@ class Metadata:
     name: Optional[str] = None
     labels: Optional[list[str]] = None
     sources: Union[list[ProjectSource], Sources] = field(default_factory=list)
+    resources: list[ProjectResource] = field(default_factory=list)
     """The object sources. This may contain an object with named attributes
     pointing to the sources or a list of ProjectSources"""
 
@@ -31,6 +38,7 @@ class Metadata:
             type=item.type,
             labels=item.labels,
             sources=item.sources,
+            resources=item.resources,
         )
 
     def raw_sources(self) -> list[ProjectSource]:


### PR DESCRIPTION
## 1.4.0

### Added

- Added the functionality for `opf2nerf` to output the `avg_pos` and `scale` when using with `--nerfstudio`.
- Added the original resources to the metadata of resolved project items.

### Fixed

- Version check for compatibility.
